### PR TITLE
Adding request validation hook

### DIFF
--- a/lib/mumukit.rb
+++ b/lib/mumukit.rb
@@ -35,9 +35,11 @@ require_relative 'mumukit/with_tempfile'
 require_relative 'mumukit/with_command_line'
 require_relative 'mumukit/test_compiler/file_test_compiler'
 require_relative 'mumukit/test_runner/file_test_runner'
+require_relative 'mumukit/request_validator/request_validation_error'
 
 require_relative 'stubs/expectations_runner'
 require_relative 'stubs/feedback_runner'
+require_relative 'stubs/request_validator'
 
 require_relative 'mumukit/server/response_builder'
 require_relative 'mumukit/server/test_server'

--- a/lib/mumukit/request_validator/request_validation_error.rb
+++ b/lib/mumukit/request_validator/request_validation_error.rb
@@ -1,0 +1,4 @@
+module Mumukit
+  class RequestValidationError < StandardError
+  end
+end

--- a/lib/mumukit/server/test_server.rb
+++ b/lib/mumukit/server/test_server.rb
@@ -5,6 +5,7 @@ class Mumukit::TestServer < Mumukit::Stub
   def run!(request)
     r = OpenStruct.new(request)
 
+    validate_request! r
     test_results = run_tests! r
     expectation_results = run_expectations! r
 
@@ -19,8 +20,14 @@ class Mumukit::TestServer < Mumukit::Stub
       add_feedback(feedback)
       build
     end
+  rescue Mumukit::RequestValidationError => e
+    {exit: :aborted, out: e.message}
   rescue Exception => e
     {exit: :errored, out: content_type.format_exception(e)}
+  end
+
+  def validate_request!(request)
+    RequestValidator.new(config).validate! request
   end
 
 

--- a/lib/stubs/request_validator.rb
+++ b/lib/stubs/request_validator.rb
@@ -1,0 +1,4 @@
+class RequestValidator < Mumukit::Stub
+  def validate!(request)
+  end
+end

--- a/spec/test_server_spec.rb
+++ b/spec/test_server_spec.rb
@@ -70,4 +70,10 @@ describe TestServer do
     before { allow_any_instance_of(FeedbackRunner).to receive(:run_feedback!).and_return('Keep up the good work!') }
     it { expect(result[:feedback]).to eq('Keep up the good work!') }
   end
+
+  context 'when request validator fails' do
+    before { allow_any_instance_of(RequestValidator).to receive(:validate!).and_raise(RequestValidationError.new('never use File.new')) }
+    it { expect(result[:exit]).to eq(:aborted) }
+    it { expect(result[:out]).to eq('never use File.new') }
+  end
 end


### PR DESCRIPTION
Related to #3 

In order to avoid malicious code sent by user and executed by the test runner, we need to validate the request. This PR adds a hook to mumukit so that it can abort the request if it doesn't look good to runner. 