### PR TITLE
Fix: Docker container creation's Volumes parameter

### DIFF
--- a/lib/mumukit/isolated_environment.rb
+++ b/lib/mumukit/isolated_environment.rb
@@ -12,7 +12,7 @@ module Mumukit
       dirnames = filenames.map { |it| Pathname.new(it).dirname }
 
       binds = dirnames.map { |it| "#{it}:#{it}" }
-      volumes = Hash[[dirnames.map { |it| [it, {}] }]]
+      volumes = Hash[dirnames.map { |it| [it, {}] }]
 
       command = yield(*filenames).split
 


### PR DESCRIPTION
From [the docs](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.15/#create-a-container):

> **Volumes** – An object mapping mountpoint paths (strings) inside the container to empty objects.

We were getting:

```
{["/my/path/", {}] => nil}
```

Instead of:

```
{ "/my/path" => {} }
```
