### PR TITLE
Namespaced runner support

### DIFF
--- a/lib/mumukit.rb
+++ b/lib/mumukit.rb
@@ -11,9 +11,6 @@ I18n.load_path += Dir[File.join(pwd, 'locales', '*.yml')]
 I18n.backend.load_translations
 
 module Mumukit
-  def self.start_request(_request)
-  end
-
   def self.current_runner=(runner)
     @current_runner = runner
   end

--- a/lib/mumukit.rb
+++ b/lib/mumukit.rb
@@ -16,6 +16,7 @@ module Mumukit
   end
 
   def self.current_runner
+    raise "no runner selected. Did you forget to set current runner's name?" unless @current_runner
     @current_runner
   end
 

--- a/lib/mumukit.rb
+++ b/lib/mumukit.rb
@@ -11,17 +11,45 @@ I18n.load_path += Dir[File.join(pwd, 'locales', '*.yml')]
 I18n.backend.load_translations
 
 module Mumukit
-  def self.configure
-    @config ||= OpenStruct.new
-    yield @config
+  def self.start_request(_request)
+  end
+
+  def self.current_runner=(runner)
+    @current_runner = runner
+  end
+
+  def self.current_runner
+    @current_runner
+  end
+
+  def self.runner_name=(name)
+    self.current_runner = Mumukit::Runner.new(name)
+  end
+
+  def self.runner_name
+    current_runner.name
+  end
+
+  def self.prefix
+    current_runner.prefix
+  end
+
+  def self.configure(&block)
+    current_runner.configure(&block)
+  end
+
+  def self.configure_defaults(&block)
+    Mumukit::Runner.configure_defaults(&block)
   end
 
   def self.config
-    @config
+    current_runner.config
   end
 end
 
-Mumukit.configure do |config|
+require_relative 'mumukit/runner'
+
+Mumukit.configure_defaults do |config|
   config.limit_script = File.join(pwd, '..', 'bin', 'limit')
   config.content_type = :plain
   config.structured = false

--- a/lib/mumukit/runner.rb
+++ b/lib/mumukit/runner.rb
@@ -1,0 +1,29 @@
+class Mumukit::Runner
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def configure
+    @config ||= self.class.default_config.clone
+    yield @config
+  end
+
+  def config
+    @config
+  end
+
+  def prefix
+    name.camelize
+  end
+
+  def self.default_config
+    @default_config
+  end
+
+  def self.configure_defaults
+    @default_config ||= OpenStruct.new
+    yield @default_config
+  end
+end

--- a/lib/mumukit/runtime/info.rb
+++ b/lib/mumukit/runtime/info.rb
@@ -1,7 +1,7 @@
 module Mumukit::RuntimeInfo
   def info
     {
-        name: Mumukit.config.runner_name,
+        name: Mumukit.runner_name,
         version: (File.read('version') rescue 'master'),
         escualo_base_version: ENV['ESCUALO_BASE_VERSION'],
         escualo_service_version: ENV['ESCUALO_SERVICE_VERSION'],

--- a/lib/mumukit/runtime/symbol.rb
+++ b/lib/mumukit/runtime/symbol.rb
@@ -1,5 +1,9 @@
 class Symbol
   def to_mumukit_hook_class_name
+    "#{Mumukit.prefix}#{to_simple_mumukit_hook_class_name}"
+  end
+
+  def to_simple_mumukit_hook_class_name
     "#{to_s.camelize.to_sym}Hook"
   end
 
@@ -8,6 +12,6 @@ class Symbol
   end
 
   def to_default_mumukit_hook_class
-    Kernel.const_get "Mumukit::Defaults::#{to_mumukit_hook_class_name}"
+    Kernel.const_get "Mumukit::Defaults::#{to_simple_mumukit_hook_class_name}"
   end
 end

--- a/lib/mumukit/server/app.rb
+++ b/lib/mumukit/server/app.rb
@@ -20,6 +20,10 @@ class Mumukit::Server::App < Sinatra::Base
     content_type 'application/json'
   end
 
+  before do
+    Mumukit.start_request(request)
+  end
+
   runtime_config = YAML.load_file(settings.config_filename) rescue nil
   server = Mumukit::Server::TestServer.new(runtime_config)
 

--- a/lib/mumukit/server/app.rb
+++ b/lib/mumukit/server/app.rb
@@ -20,18 +20,18 @@ class Mumukit::Server::App < Sinatra::Base
     content_type 'application/json'
   end
 
-  before do
-    Mumukit.start_request(request)
-  end
-
   runtime_config = YAML.load_file(settings.config_filename) rescue nil
   server = Mumukit::Server::TestServer.new(runtime_config)
 
+  before do
+    server.start_request!(parse_request)
+  end
+
   helpers do
     def parse_request
-      r = JSON.parse(request.body.read)
-      I18n.locale = r['locale'] || :en
-      r
+      @parsed_request ||= JSON.parse(request.body.read).tap do |it|
+        I18n.locale = it['locale'] || :en
+      end
     end
   end
 

--- a/lib/mumukit/server/test_server.rb
+++ b/lib/mumukit/server/test_server.rb
@@ -14,6 +14,9 @@ class Mumukit::Server::TestServer
     runtime.info.merge(runtime.metadata_hook.metadata).merge(url: url)
   end
 
+  def start_request!(_raw_request)
+  end
+
   def test!(raw_request)
     respond_to(raw_request) do |r|
       test_results = run_tests! r
@@ -71,16 +74,15 @@ class Mumukit::Server::TestServer
   end
 
   def parse_request(request)
-    OpenStruct.new(request).tap { |r| validate_request! r }
+    OpenStruct.new(request)
   end
 
   def validate_request!(request)
     runtime.validation_hook.validate! request
   end
 
-
   def respond_to(raw_request)
-    yield parse_request(raw_request)
+    yield parse_request(raw_request).tap { |r| validate_request! r }
   rescue Mumukit::RequestValidationError => e
     {exit: :aborted, out: e.message}
   rescue Exception => e

--- a/spec/file_test_runner_spec.rb
+++ b/spec/file_test_runner_spec.rb
@@ -14,6 +14,7 @@ class IsolatedEnvTestRunner < BaseTestRunner
   isolated true
 end
 
+Mumukit.runner_name = 'demo'
 Mumukit.configure do |c|
   c.docker_image = 'ubuntu'
 end
@@ -43,12 +44,12 @@ describe Mumukit::Runtime do
 
   context 'when test runner is isolated' do
     before do
-      class TestHook < IsolatedEnvTestRunner
+      class DemoTestHook < IsolatedEnvTestRunner
       end
     end
 
     after do
-      drop_hook TestHook
+      drop_hook DemoTestHook
     end
 
     it { expect(runtime.test_hook?).to be true }
@@ -57,12 +58,12 @@ describe Mumukit::Runtime do
 
   context 'when test runner is embedded' do
     before do
-      class TestHook < EmbeddedEnvTestRunner
+      class DemoTestHook < EmbeddedEnvTestRunner
       end
     end
 
     after do
-      drop_hook TestHook
+      drop_hook DemoTestHook
     end
 
     it { expect(runtime.info[:features][:sandboxed]).to be false }

--- a/spec/mulang_expectations_hook_spec.rb
+++ b/spec/mulang_expectations_hook_spec.rb
@@ -6,14 +6,14 @@ describe Mumukit::Templates::MulangExpectationsHook do
   let(:expectations) { [usesX] }
 
   after do
-    drop_hook ExpectationsHook
+    drop_hook DemoExpectationsHook
   end
 
-  let(:hook) { ExpectationsHook.new('mulang_path' => './bin/mulang') }
+  let(:hook) { DemoExpectationsHook.new('mulang_path' => './bin/mulang') }
 
   context 'integration' do
     before do
-      class ExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+      class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
         include_smells true
 
         def language
@@ -36,14 +36,14 @@ describe Mumukit::Templates::MulangExpectationsHook do
 
   context '#run!' do
     def mock_mulang_output(output)
-      allow_any_instance_of(ExpectationsHook).to receive(:run_command).and_return([output, :passed])
+      allow_any_instance_of(DemoExpectationsHook).to receive(:run_command).and_return([output, :passed])
     end
 
     let(:request) { { content: content, expectations: expectations } }
 
     context 'when language is not defined' do
       before do
-        class ExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+        class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
         end
       end
 
@@ -52,7 +52,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
 
     context 'transforms the results json into a hash' do
       before do
-        class ExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+        class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
           def language
             'Haskell'
           end
@@ -68,7 +68,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
 
     context 'when smells are enabled' do
       before do
-        class ExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+        class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
           include_smells true
 
           def language
@@ -90,7 +90,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
   context '#mulang_input' do
     context 'with defaults' do
       before do
-        class ExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+        class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
           def language
             'Haskell'
           end
@@ -102,7 +102,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
 
     context 'when transform_content is provided' do
       before do
-        class ExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+        class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
           def language
             'Haskell'
           end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -2,7 +2,7 @@ require_relative './spec_helper'
 
 describe Mumukit::Server::TestServer do
   before do
-    class QueryHook < Mumukit::Templates::FileHook
+    class DemoQueryHook < Mumukit::Templates::FileHook
       isolated false
 
       def command_line(filename)
@@ -16,7 +16,7 @@ describe Mumukit::Server::TestServer do
   end
 
   after do
-    drop_hook QueryHook
+    drop_hook DemoQueryHook
   end
 
   let(:server) { Mumukit::Server::TestServer.new(nil) }

--- a/spec/stub_spec.rb
+++ b/spec/stub_spec.rb
@@ -2,10 +2,10 @@ require_relative './spec_helper.rb'
 
 describe Mumukit::Hook do
 
-  class TestStub < Mumukit::Hook
+  class DemoTestStub < Mumukit::Hook
   end
 
-  let(:an_stub) { TestStub.new(foo: 'bar') }
+  let(:an_stub) { DemoTestStub.new(foo: 'bar') }
 
   it { expect(an_stub.foo).to eq 'bar' }
   it { expect { an_stub.baz }.to raise_error(NoMethodError) }

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -17,23 +17,23 @@ describe Mumukit::Server::TestServer do
 
   context 'when test runner is implemented but no expectations' do
     before do
-      class TestHook < IntegrationTestBaseTestHook
+      class DemoTestHook < IntegrationTestBaseTestHook
       end
     end
     after do
-      drop_hook TestHook
+      drop_hook DemoTestHook
     end
 
     it { expect(info[:expectations]).to be false }
 
     context 'when test passes' do
-      before { allow_any_instance_of(TestHook).to receive(:run!).and_return(['ok', :passed]) }
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return(['ok', :passed]) }
 
       it { expect(result).to eq({out: 'ok', exit: :passed}) }
     end
 
     context 'when test returns structured results' do
-      before { allow_any_instance_of(TestHook).to receive(:run!).and_return([[['foo', :passed, ''], ['baz', :failed, 'bar']]]) }
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return([[['foo', :passed, ''], ['baz', :failed, 'bar']]]) }
 
       it { expect(result).to eq({testResults: [
           {title: 'foo', status: :passed, result: ''},
@@ -41,37 +41,37 @@ describe Mumukit::Server::TestServer do
     end
 
     context 'when test fails' do
-      before { allow_any_instance_of(TestHook).to receive(:run!).and_return(['nok', :failed]) }
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return(['nok', :failed]) }
 
       it { expect(result).to eq({out: 'nok', exit: :failed}) }
     end
 
     context 'when test runner crashes' do
-      before { allow_any_instance_of(TestHook).to receive(:run!).and_raise('ups!') }
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_raise('ups!') }
       it { expect(result[:exit]).to eq(:errored) }
       it { expect(result[:out]).to include('ups!') }
     end
 
     context 'when test is aborted' do
-      before { allow_any_instance_of(TestHook).to receive(:run!).and_return(['out of memory error', :aborted]) }
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return(['out of memory error', :aborted]) }
 
       it { expect(result).to eq({out: 'out of memory error', exit: :aborted}) }
     end
     context 'when feedback runner is implemented' do
       before do
-        class FeedbackHook < Mumukit::Hook
+        class DemoFeedbackHook < Mumukit::Hook
         end
       end
 
       after do
-        drop_hook FeedbackHook
+        drop_hook DemoFeedbackHook
       end
 
       it { expect(info[:feedback]).to be true }
 
       context 'when feedback is given' do
-        before { allow_any_instance_of(TestHook).to receive(:run!).and_return(['ok', :passed]) }
-        before { allow_any_instance_of(FeedbackHook).to receive(:run!).and_return('Keep up the good work!') }
+        before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return(['ok', :passed]) }
+        before { allow_any_instance_of(DemoFeedbackHook).to receive(:run!).and_return('Keep up the good work!') }
         it { expect(result[:feedback]).to eq('Keep up the good work!') }
       end
     end
@@ -79,31 +79,31 @@ describe Mumukit::Server::TestServer do
 
   context 'when expectations and test runner are implemented' do
     before do
-      class ExpectationsHook < Mumukit::Hook
+      class DemoExpectationsHook < Mumukit::Hook
       end
-      class TestHook < IntegrationTestBaseTestHook
+      class DemoTestHook < IntegrationTestBaseTestHook
       end
     end
 
     after do
-      drop_hook TestHook
-      drop_hook ExpectationsHook
+      drop_hook DemoTestHook
+      drop_hook DemoExpectationsHook
     end
 
     it { expect(info[:expectations]).to be true }
 
     context 'when both passed' do
       let(:expectation_results) { [{expectation: {binding: :foo, inspection: :HasUsage}, result: true}] }
-      before { allow_any_instance_of(TestHook).to receive(:run!).and_return(['ok', :passed]) }
-      before { allow_any_instance_of(ExpectationsHook).to receive(:compile) }
-      before { allow_any_instance_of(ExpectationsHook).to receive(:run!).and_return(expectation_results) }
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return(['ok', :passed]) }
+      before { allow_any_instance_of(DemoExpectationsHook).to receive(:compile) }
+      before { allow_any_instance_of(DemoExpectationsHook).to receive(:run!).and_return(expectation_results) }
 
       it { expect(result).to eq({out: 'ok', exit: :passed, expectationResults: expectation_results}) }
     end
     context 'when expectations crash' do
-      before { allow_any_instance_of(TestHook).to receive(:run!).and_return(['ok', :passed]) }
-      before { allow_any_instance_of(ExpectationsHook).to receive(:compile) }
-      before { allow_any_instance_of(ExpectationsHook).to receive(:run!).and_raise('ups!') }
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return(['ok', :passed]) }
+      before { allow_any_instance_of(DemoExpectationsHook).to receive(:compile) }
+      before { allow_any_instance_of(DemoExpectationsHook).to receive(:run!).and_raise('ups!') }
 
       it { expect(result[:exit]).to eq(:errored) }
       it { expect(result[:out]).to include('ups!') }
@@ -112,19 +112,19 @@ describe Mumukit::Server::TestServer do
 
   context 'when there are no tests but expectations' do
     before do
-      class ExpectationsHook < Mumukit::Hook
+      class DemoExpectationsHook < Mumukit::Hook
       end
     end
 
     after do
-      drop_hook ExpectationsHook
+      drop_hook DemoExpectationsHook
     end
 
     let(:expectation_results) { [{expectation: {binding: :foo, inspection: :HasUsage}, result: true}] }
     let(:result) { server.test!('content' => 'foo', 'expectations' => [{binding: :foo, inspection: :HasUsage}]) }
 
-    before { allow_any_instance_of(ExpectationsHook).to receive(:compile) }
-    before { allow_any_instance_of(ExpectationsHook).to receive(:run!).and_return(expectation_results) }
+    before { allow_any_instance_of(DemoExpectationsHook).to receive(:compile) }
+    before { allow_any_instance_of(DemoExpectationsHook).to receive(:run!).and_return(expectation_results) }
 
     it { expect(result).to eq({out: '', exit: :passed, expectationResults: expectation_results}) }
   end
@@ -132,19 +132,19 @@ describe Mumukit::Server::TestServer do
 
   context 'when request is implemented' do
     before do
-      class ValidationHook < Mumukit::Hook
+      class DemoValidationHook < Mumukit::Hook
       end
     end
 
     after do
-      drop_hook ValidationHook
+      drop_hook DemoValidationHook
     end
 
     it { expect(info[:secure]).to be true }
 
     context 'when validation fails' do
       before do
-        allow_any_instance_of(ValidationHook).to receive(:validate!).and_raise(Mumukit::RequestValidationError.new('never use File.new'))
+        allow_any_instance_of(DemoValidationHook).to receive(:validate!).and_raise(Mumukit::RequestValidationError.new('never use File.new'))
       end
       it { expect(result[:exit]).to eq(:aborted) }
       it { expect(result[:out]).to eq('never use File.new') }


### PR DESCRIPTION
Now that Mumuki has more and more runners, deploy of them is getting really complex: you need to deploy a different server for each runner, which is a great pain in the neck. 

It means you need also to manually escale each language runner, and it is also a waste of system resources: you need to deploy an instance of each runner, and idle runners consume resources of most demanded ones. 

So I am introducing a non backward compatible change: namespaced hooks - in new versions of runners, you will not write a `TestHook` class, but a `PythonTestHook` class, which allows them to be reused and dynamically choosen. 

