### PR TITLE
Allow mashup to map fields before joining

### DIFF
--- a/lib/mumukit/templates/file_hook.rb
+++ b/lib/mumukit/templates/file_hook.rb
@@ -65,8 +65,9 @@ module Mumukit
       end
     end
 
-    def self.mashup(*args)
+    def self.mashup(*args, &map_block)
       include Mumukit::Templates::WithMashupFileContent
+      define_method(:map_fields, &map_block) if block_given?
 
       args = args.present? ? args : [:extra, :content, :test]
 

--- a/lib/mumukit/templates/file_hook.rb
+++ b/lib/mumukit/templates/file_hook.rb
@@ -67,7 +67,7 @@ module Mumukit
 
     def self.mashup(*args, &map_block)
       include Mumukit::Templates::WithMashupFileContent
-      define_method(:map_fields, &map_block) if block_given?
+      define_method(:map_mashup_fields, &map_block) if block_given?
 
       args = args.present? ? args : [:extra, :content, :test]
 

--- a/lib/mumukit/templates/with_mashup_file_content.rb
+++ b/lib/mumukit/templates/with_mashup_file_content.rb
@@ -1,14 +1,14 @@
 module Mumukit
   module Templates::WithMashupFileContent
     def compile_file_content(request)
-      map_fields(mashup_fields.map { |field| request.public_send field }).join("\n")
+      map_mashup_fields(mashup_fields.map { |field| request.public_send field }).join("\n")
     end
 
     def mashup_fields
       raise 'must define mashup fields'
     end
 
-    def map_fields(fields)
+    def map_mashup_fields(fields)
     	fields
     end
   end

--- a/lib/mumukit/templates/with_mashup_file_content.rb
+++ b/lib/mumukit/templates/with_mashup_file_content.rb
@@ -1,11 +1,15 @@
 module Mumukit
   module Templates::WithMashupFileContent
     def compile_file_content(request)
-      mashup_fields.map { |field| request.public_send field }.join("\n")
+      map_fields(mashup_fields.map { |field| request.public_send field }).join("\n")
     end
 
     def mashup_fields
       raise 'must define mashup fields'
+    end
+
+    def map_fields(fields)
+    	fields
     end
   end
 end


### PR DESCRIPTION
Add an optional parameter to mashup directive to enable mapping fields before joining them