### PR TITLE
add * operator to allow separating fields in mashup block

### DIFF
--- a/lib/mumukit/templates/with_mashup_file_content.rb
+++ b/lib/mumukit/templates/with_mashup_file_content.rb
@@ -1,7 +1,7 @@
 module Mumukit
   module Templates::WithMashupFileContent
     def compile_file_content(request)
-      map_mashup_fields(mashup_fields.map { |field| request.public_send field }).join("\n")
+      map_mashup_fields(*mashup_fields.map { |field| request.public_send field }).join("\n")
     end
 
     def mashup_fields


### PR DESCRIPTION
Necessary to implement this solution: https://github.com/mumuki/mumuki-ruby-runner/pull/30#discussion_r135869279