### PR TITLE
add * operator to allow separating fields in mashup block

### DIFF
--- a/lib/mumukit/templates/with_mashup_file_content.rb
+++ b/lib/mumukit/templates/with_mashup_file_content.rb
@@ -1,14 +1,14 @@
 module Mumukit
   module Templates::WithMashupFileContent
     def compile_file_content(request)
-      map_mashup_fields(mashup_fields.map { |field| request.public_send field }).join("\n")
+      map_mashup_fields(*mashup_fields.map { |field| request.public_send field }).join("\n")
     end
 
     def mashup_fields
       raise 'must define mashup fields'
     end
 
-    def map_mashup_fields(fields)
+    def map_mashup_fields(*fields)
     	fields
     end
   end


### PR DESCRIPTION
Necessary to implement this solution: mumuki/mumuki-ruby-runner#30 (comment)