### PR TITLE
Trim whitespace when checking equality in interactive queries

### DIFF
--- a/lib/mumukit/metatest/interactive_checker.rb
+++ b/lib/mumukit/metatest/interactive_checker.rb
@@ -7,7 +7,7 @@ module Mumukit::Metatest
 
     def check_last_query_equals(_result, goal)
       expected = goal[:value]
-      actual = @request.query
+      actual = @request.query.strip
       fail_t :check_last_query_equals, expected: expected, actual: actual unless expected == actual
     end
 
@@ -21,15 +21,15 @@ module Mumukit::Metatest
     end
 
     def check_last_query_outputs(result, goal)
-      compare_last_query_by(:check_last_query_outputs, result, goal) { |expected, actual| expected == actual }
+      compare_last_query_by(:check_last_query_outputs, result, goal) {|expected, actual| expected == actual}
     end
 
     def check_last_query_output_includes(result, goal)
-      compare_last_query_by(:check_last_query_output_includes, result, goal) { |expected, actual| actual.include? expected }
+      compare_last_query_by(:check_last_query_output_includes, result, goal) {|expected, actual| actual.include? expected}
     end
 
     def check_last_query_output_like(result, goal)
-      compare_last_query_by(:check_last_query_output_like, result, goal) { |expected, actual| normalize(expected) == normalize(actual) }
+      compare_last_query_by(:check_last_query_output_like, result, goal) {|expected, actual| normalize(expected) == normalize(actual)}
     end
 
     def compare_last_query_by(sym, result, goal, &condition)

--- a/spec/try_spec.rb
+++ b/spec/try_spec.rb
@@ -51,7 +51,7 @@ describe Mumukit::Metatest::InteractiveChecker do
   before { allow_any_instance_of(DemoTryHook).to receive(:to_structured_results).and_return structured_results }
 
   context 'when using string keys' do
-    let(:goal) { { 'kind' => 'last_query_equals', 'value' => 'echo something' } }
+    let(:goal) { {kind: 'last_query_equals', value: 'echo something' } }
     let(:request) { struct query: 'echo something', goal: goal }
     it { expect(result[1]).to eq :passed }
   end
@@ -61,6 +61,11 @@ describe Mumukit::Metatest::InteractiveChecker do
 
     context 'and query that matches' do
       let(:request) { struct query: 'echo something', goal: goal }
+      it { expect(result[1]).to eq :passed }
+    end
+
+    context 'and query with superfluous spaces that matches' do
+      let(:request) { struct query: '  echo something  ', goal: goal }
       it { expect(result[1]).to eq :passed }
     end
 


### PR DESCRIPTION
Fixes #85 