### PR TITLE
adding with assets server mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ Finally, `mumukit` templates provides the following _extensions_ - features that
   * `isolated`: lets to run commands within docker or in native environment
 * `Mumukit::Templates::MulangExpectationsHook`
   * `include_smells`: lets to include in the result smells produced by _mulang_
+  
+## Server extensions
+
+If you need to serve assets, you can include the `Mumukit::Server::WithAssets` mixin which enables cross origin requests and provides `get_asset` and `get_local_asset` methods

--- a/lib/mumukit/server.rb
+++ b/lib/mumukit/server.rb
@@ -6,3 +6,4 @@ end
 require_relative './server/response_builder'
 require_relative './server/test_pipeline'
 require_relative './server/test_server'
+require_relative './server/with_assets'

--- a/lib/mumukit/server/app.rb
+++ b/lib/mumukit/server/app.rb
@@ -2,7 +2,6 @@ require 'sinatra/base'
 require 'yaml'
 require 'json'
 
-
 class Mumukit::Server::App < Sinatra::Base
   configure do
     set :mumuki_url, 'http://mumuki.io'

--- a/lib/mumukit/server/with_assets.rb
+++ b/lib/mumukit/server/with_assets.rb
@@ -1,3 +1,7 @@
+require 'sinatra/base'
+require 'mime/types'
+require 'sinatra/cross_origin'
+
 module Mumukit::Server::WithAssets
   extend ActiveSupport::Concern
 
@@ -10,14 +14,27 @@ module Mumukit::Server::WithAssets
   end
 
   class_methods do
-
-    def get_asset(route, absolute_path, type)
+    def get_asset(route, absolute_path, type=nil)
+      type ||= infer_asset_type_from(route)
       get "/assets/#{route}" do
         cross_origin
         send_file absolute_path, type: type
       end
     end
 
+    def infer_asset_type_from(route)
+      extension = File.extname(route)
+      MIME::Types.type_for(extension).first.content_type
+    end
+
+    def get_local_asset(route, path, type=nil)
+      get_asset route, File.join(local_asset_dir, '..', path), type
+    end
+
+    def local_asset_dir
+      @local_asset_dir ||= File.dirname caller[1].split(':')[0]
+      # Had to use caller[1] because the first entry of the stack is from this file
+    end
   end
 end
 

--- a/lib/mumukit/server/with_assets.rb
+++ b/lib/mumukit/server/with_assets.rb
@@ -1,0 +1,23 @@
+module Mumukit::Server::WithAssets
+  extend ActiveSupport::Concern
+
+  included do
+    register Sinatra::CrossOrigin
+
+    configure do
+      set :allow_origin, '*'
+    end
+  end
+
+  class_methods do
+
+    def get_asset(route, absolute_path, type)
+      get "/assets/#{route}" do
+        cross_origin
+        send_file absolute_path, type: type
+      end
+    end
+
+  end
+end
+

--- a/mumukit.gemspec
+++ b/mumukit.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'puma'
   spec.add_dependency 'docker-api', '~> 1.22.2'
   spec.add_dependency 'excon', '~> 0.46'
+  spec.add_dependency 'sinatra-cross_origin', '~> 0.4'
+  spec.add_dependency 'mime-types', '~> 3.2'
 
   spec.add_dependency 'mulang', '~> 4.0'
 


### PR DESCRIPTION
I need to create an assets server for the html runner as well, so I think it's a good moment to move this behavior to a mixin.
Also, I moved the cross_origin call to the actual method, in order to avoid it being applied for every request.