### PR TITLE
Chore improve metatest hooks

### DIFF
--- a/lib/mumukit/metatest/checker.rb
+++ b/lib/mumukit/metatest/checker.rb
@@ -25,9 +25,9 @@ module Mumukit::Metatest
     ##
     def check(input, example)
       check_assertions input, postconditions_for(example), example
-      [example[:name], :passed, render_success_output(input)]
+      build_passed_test_result example, input
     rescue => e
-      [example[:name], :failed, render_error_output(input, e.message)]
+      build_failed_test_result example, input, e
     end
 
     ## If no postconditions are included in the example,
@@ -64,6 +64,14 @@ module Mumukit::Metatest
 
     def error(message)
       raise Mumukit::Metatest::Errored, message
+    end
+
+    def build_passed_test_result(example, input)
+      [example[:name], :passed, render_success_output(input)]
+    end
+
+    def build_failed_test_result(example, input, e)
+      [example[:name], :failed, render_error_output(input, e.message)]
     end
   end
 end

--- a/lib/mumukit/metatest/checker.rb
+++ b/lib/mumukit/metatest/checker.rb
@@ -40,8 +40,19 @@ module Mumukit::Metatest
       nil
     end
 
-    def render_error_output(value, error)
-      error
+    # Implementors should override this method if they want access to
+    # the error details
+    def render_error_output_with_details(value, error_message, _error_details)
+      render_error_output value, error_message
+    end
+
+    # Implementors may override this method instead of `render_error_output_with_details`
+    # if they don't want to handle error details.
+    #
+    # This method is only for backward compatibility. New code
+    # should use `render_error_output_with_details`.
+    def render_error_output(value, error_message)
+      error_message
     end
 
     def check_assertions(input, assertions_hash, example)
@@ -54,16 +65,16 @@ module Mumukit::Metatest
       send "check_#{assertion_name}", input, assertion_config
     end
 
-    def fail(message)
-      raise Mumukit::Metatest::Failed, message
+    def fail(message, details: nil)
+      raise Mumukit::Metatest::Failed.new(message, details)
     end
 
-    def abort(message)
-      raise Mumukit::Metatest::Aborted, message
+    def abort(message, details: nil)
+      raise Mumukit::Metatest::Aborted.new(message, details)
     end
 
-    def error(message)
-      raise Mumukit::Metatest::Errored, message
+    def error(message, details: nil)
+      raise Mumukit::Metatest::Errored.new(message, details)
     end
 
     def build_passed_test_result(example, input)
@@ -71,7 +82,7 @@ module Mumukit::Metatest
     end
 
     def build_failed_test_result(example, input, e)
-      [example[:name], :failed, render_error_output(input, e.message)]
+      [example[:name], :failed, render_error_output_with_details(input, e.message, e.details)]
     end
   end
 end

--- a/lib/mumukit/metatest/errors.rb
+++ b/lib/mumukit/metatest/errors.rb
@@ -1,10 +1,17 @@
 module Mumukit::Metatest
-  class Aborted < StandardError
+  class BaseError < StandardError
+    attr_reader :details
+    def initialize(message = "", details = nil)
+      super(message)
+      @details = details
+    end
+  end
+  class Aborted < BaseError
   end
 
-  class Errored < StandardError
+  class Errored < BaseError
   end
 
-  class Failed < StandardError
+  class Failed < BaseError
   end
 end

--- a/spec/mulang_expectations_hook_spec.rb
+++ b/spec/mulang_expectations_hook_spec.rb
@@ -55,7 +55,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
 
       let(:result) { compile_and_run request }
 
-      it { expect(result.length).to eq 6 }
+      it { expect(result.length).to eq 7 }
 
       it { expect(result).to include(expectation: declaresComputationWithArity1, result: true) }
 


### PR DESCRIPTION
This PR allows checker to raise expectations with details. That enables to handle additional test information without having to serialize it and then deserialize - this is for example what gobstones runner currently does - creates a JSON string before raising the exception and then it parses again after handling it, which is both cumbersome and inefficient 
