### PR TITLE
Feature test summary

### DIFF
--- a/lib/mumukit/metatest.rb
+++ b/lib/mumukit/metatest.rb
@@ -3,6 +3,7 @@ end
 
 require_relative './metatest/errors'
 require_relative './metatest/checker'
+require_relative './metatest/test_result_builder'
 require_relative './metatest/interactive_checker'
 require_relative './metatest/framework'
 require_relative './metatest/identity_runner'

--- a/lib/mumukit/metatest/test_result_builder.rb
+++ b/lib/mumukit/metatest/test_result_builder.rb
@@ -8,7 +8,7 @@ module Mumukit::Metatest
 
     def build
       raise 'missing status' unless status
-      raise "invallid #{status}" unless status.passed? || status.failed?
+      raise "invalid #{status}" unless status.passed? || status.failed?
 
       if summary_message.present? || summary_type.present?
         [title, status, result, summary]

--- a/lib/mumukit/metatest/test_result_builder.rb
+++ b/lib/mumukit/metatest/test_result_builder.rb
@@ -1,0 +1,20 @@
+module Mumukit::Metatest
+  class TestResultBuilder
+    attr_accessor :title, :status, :result, :summary_type, :summary_message
+
+    def summary
+      {type: summary_type.presence, message: summary_message.presence}.compact
+    end
+
+    def build
+      raise 'missing status' unless status
+      raise "invallid #{status}" unless status.passed? || status.failed?
+
+      if summary_message.present? || summary_type.present?
+        [title, status, result, summary]
+      else
+        [title, status, result]
+      end
+    end
+  end
+end

--- a/lib/mumukit/server/response_builder.rb
+++ b/lib/mumukit/server/response_builder.rb
@@ -58,10 +58,16 @@ class Mumukit::Server::ResponseBuilder
   end
 
   def structured_base_response(test_results)
-    {testResults: test_results[0].map { |title, status, result|
-      {title: title,
-       status: status,
-       result: result} }}
+    {
+      testResults: test_results[0].map do |title, status, result, summary|
+        { summary: summary&.compact.presence }
+          .compact
+          .merge(
+            title: title,
+            status: status,
+            result: result)
+      end
+    }
   end
 
   def unstructured_base_response(test_results)

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -272,6 +272,39 @@ alert("!");
           {title: 'baz', status: :failed, result: 'bar'}] }
     end
 
+    context 'when test returns structured results with failed summary' do
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return([[['foo', :passed, ''], ['baz', :failed, 'bar', {key: 'foobaz', message: 'Foo Baz'}]]]) }
+
+      it { expect(result).to eq testResults: [
+          {title: 'foo', status: :passed, result: ''},
+          {title: 'baz', status: :failed, result: 'bar', summary: {key: 'foobaz', message: 'Foo Baz'}}] }
+    end
+
+    context 'when test returns structured results with empty summary' do
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return([[['foo', :passed, ''], ['baz', :failed, 'bar', {}]]]) }
+
+      it { expect(result).to eq testResults: [
+          {title: 'foo', status: :passed, result: ''},
+          {title: 'baz', status: :failed, result: 'bar'}] }
+    end
+
+    context 'when test returns structured results with summary with empty keys' do
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return([[['foo', :passed, ''], ['baz', :failed, 'bar', {key: nil}]]]) }
+
+      it { expect(result).to eq testResults: [
+          {title: 'foo', status: :passed, result: ''},
+          {title: 'baz', status: :failed, result: 'bar'}] }
+    end
+
+
+    context 'when test returns structured results with passed summary' do
+      before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return([[['foo', :passed, '', {key: 'foobaz', message: 'Foo Baz'}], ['baz', :failed, 'bar']]]) }
+
+      it { expect(result).to eq testResults: [
+          {title: 'foo', status: :passed, result: '', summary: {key: 'foobaz', message: 'Foo Baz'}},
+          {title: 'baz', status: :failed, result: 'bar'}] }
+    end
+
     context 'when test fails' do
       before { allow_any_instance_of(DemoTestHook).to receive(:run!).and_return(['nok', :failed]) }
 


### PR DESCRIPTION
Rebase after #103 

This PR introduces a new summary `feature`.

It allows checker to produce results with a `summary` - a test result payload that is in-between an expectation and a test result. It has structured information `summary.key` and unstructured information `summary.message`. 

It also introduces a `TestResultBuilder` that makes test result structure to evolve without having to manually handling lists of 3, 4 o N elements which is the underlying representation of a test result in mumukit. 

 PS: I am also working on using those new features in gobstones-runner - https://github.com/mumuki/mumuki-gobstones-runner/pull/180-  as a first case of adoption, and also in bridge - https://github.com/mumuki/mumukit-bridge/pull/20 -, so that it can expose the extended test results structure in a backward compatible way. 