### PR TITLE
Feature add format explainers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'mumukit-content-type', github: 'mumuki/mumukit-content-type', branch: 'chore-add-enumerations'
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source 'https://rubygems.org'
+
+gem 'mumukit-content-type', github: 'mumuki/mumukit-content-type', branch: 'chore-add-enumerations'
+
 gemspec

--- a/lib/mumukit/explainer.rb
+++ b/lib/mumukit/explainer.rb
@@ -1,11 +1,15 @@
 class Mumukit::Explainer
+  include Mumukit::WithContentType
+
   def explain(content, test_results)
+    content_type.enumerate(explanations(content, test_results))
+  end
+
+  def explanations(content, test_results)
     explain_methods
         .map { |selector, key| eval_explain(selector, key, content, test_results) }
         .compact
         .map { |explain| I18n.t(explain[:key], explain[:binding]) }
-        .map { |it| "* #{it}" }
-        .join("\n")
   end
 
   def eval_explain(selector, key, content, test_results)

--- a/lib/mumukit/explainer.rb
+++ b/lib/mumukit/explainer.rb
@@ -5,6 +5,8 @@ class Mumukit::Explainer
     content_type.enumerate(explanations(content, test_results))
   end
 
+  private
+
   def explanations(content, test_results)
     explain_methods
         .map { |selector, key| eval_explain(selector, key, content, test_results) }

--- a/mumukit.gemspec
+++ b/mumukit.gemspec
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'mumukit-core', '~> 1.3'
   spec.add_dependency 'mumukit-directives', '~> 0.4'
-  spec.add_dependency 'mumukit-content-type', '>= 0.2', '< 2'
+  spec.add_dependency 'mumukit-content-type', '~> 1.10'
 end

--- a/spec/explainer_spec.rb
+++ b/spec/explainer_spec.rb
@@ -2,9 +2,32 @@ require_relative 'spec_helper'
 
 class SampleExplainer < Mumukit::Explainer
   def explain_foo(content, test_results)
+    'foo'
   end
 end
 
 describe Mumukit::Explainer do
-  it { expect(SampleExplainer.new.explain_methods).to eq [[:explain_foo, 'foo']] }
+  context 'contains all explain methods' do
+    it { expect(SampleExplainer.new.explain_methods).to eq [[:explain_foo, 'foo']] }
+  end
+
+  context 'explains in html' do
+    before do
+      Mumukit.configure do |config|
+        config.content_type = 'html'
+      end
+    end
+
+    it { expect(SampleExplainer.new.explain('code', 'errored')).to match(/<ul>\n<li>.*foo.*<\/li>\n<\/ul>/) }
+  end
+
+  context 'explains in markdown' do
+    before do
+      Mumukit.configure do |config|
+        config.content_type = 'markdown'
+      end
+    end
+
+    it { expect(SampleExplainer.new.explain('code', 'errored')).to match(/\* .*foo.*/) }
+  end
 end

--- a/spec/explainer_spec.rb
+++ b/spec/explainer_spec.rb
@@ -8,7 +8,7 @@ end
 
 describe Mumukit::Explainer do
   context 'contains all explain methods' do
-    it { expect(SampleExplainer.new.explain_methods).to eq [[:explain_foo, 'foo']] }
+    it { expect(SampleExplainer.new.send(:explain_methods)).to eq [[:explain_foo, 'foo']] }
   end
 
   context 'explains in html' do


### PR DESCRIPTION
## :dart: Goal 

~Extend~ Modify `Explainer` so we can format explanations in HTML - the Gobstones runner needs this, for example - instead of using Markdown by default.

## :warning: Requirements

Requires a new mumukit-content-type after merging https://github.com/mumuki/mumukit-content-type/pull/15

## ~:warning: Note on existing runners~

~Runners that currently extend `Explainer` should switch to `MarkdownExplainer` if they update mumukit. I could update our current runners now so we don't forget, if needed.~

## :question: Question

About the last commit, I'm positive they should all be private but I'm not 100% sure.

Also, I had to resort to testing through regex because explanations would return a `translation missing` text, and testing equality with a text containing `translation missing` is even uglier.