### PR TITLE
Update mulang to version 6

### DIFF
--- a/lib/mumukit/templates/mulang_expectations_hook.rb
+++ b/lib/mumukit/templates/mulang_expectations_hook.rb
@@ -2,12 +2,12 @@ require 'mulang'
 
 module Mumukit
   class Templates::MulangExpectationsHook < Mumukit::Templates::ExpectationsHook
-    LOGIC_SMELLS = %w(UsesCut UsesFail UsesUnificationOperator HasRedundantReduction)
-    FUNCTIONAL_SMELLS = %w(HasRedundantParameter HasRedundantGuards)
-    OBJECT_ORIENTED_SMELLS = %w(DoesNullTest ReturnsNull)
-    IMPERATIVE_SMELLS = %w(HasRedundantLocalVariableReturn HasAssignmentReturn)
-    EXPRESSIVENESS_SMELLS = %w(HasTooShortIdentifiers HasWrongCaseIdentifiers HasMisspelledIdentifiers)
-    GENERIC_SMELLS = %w(IsLongCode HasCodeDuplication HasRedundantLambda HasRedundantIf DoesTypeTest HasRedundantBooleanComparison HasEmptyIfBranches)
+    LOGIC_SMELLS = Mulang::Expectation::LOGIC_SMELLS
+    FUNCTIONAL_SMELLS = Mulang::Expectation::FUNCTIONAL_SMELLS
+    OBJECT_ORIENTED_SMELLS = Mulang::Expectation::OBJECT_ORIENTED_SMELLS
+    IMPERATIVE_SMELLS = Mulang::Expectation::IMPERATIVE_SMELLS
+    EXPRESSIVENESS_SMELLS = Mulang::Expectation::EXPRESSIVENESS_SMELLS
+    GENERIC_SMELLS = Mulang::Expectation::GENERIC_SMELLS
 
     required :language, 'You have to provide a Mulang-compatible language in order to use this hook'
 
@@ -16,14 +16,15 @@ module Mumukit
     end
 
     def compile_mulang_analysis(request, expectations)
-      mulang_code(request).analysis(
+      mulang_code(request).analysis({
         expectations: expectations[:ast],
         customExpectations: expectations[:custom],
         smellsSet: {
           tag: 'AllSmells',
           exclude: (expectations[:exceptions] + default_smell_exceptions)
         },
-        domainLanguage: domain_language)
+        domainLanguage: domain_language
+      }.merge({normalizationOptions: normalization_options(request).presence}.compact))
     end
 
     def run_mulang_analysis(analysis)
@@ -39,6 +40,10 @@ module Mumukit
         minimumIdentifierSize: 3,
         jargon: []
       }
+    end
+
+    def normalization_options(request)
+      request.dig(:settings, :normalization_options) || {}
     end
 
     def default_smell_exceptions

--- a/mumukit.gemspec
+++ b/mumukit.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sinatra-cross_origin', '~> 0.4'
   spec.add_dependency 'mime-types', '~> 3.2'
 
-  spec.add_dependency 'mulang', '~> 5.1'
+  spec.add_dependency 'mulang', '~> 6.0'
   spec.add_dependency 'mumukit-inspection', '~> 5.0'
 
   spec.add_dependency 'mumukit-core', '~> 1.3'

--- a/mumukit.gemspec
+++ b/mumukit.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mime-types', '~> 3.2'
 
   spec.add_dependency 'mulang', '~> 6.0'
-  spec.add_dependency 'mumukit-inspection', '~> 5.0'
+  spec.add_dependency 'mumukit-inspection', '~> 6.0'
 
   spec.add_dependency 'mumukit-core', '~> 1.3'
   spec.add_dependency 'mumukit-directives', '~> 0.4'


### PR DESCRIPTION
# :dart: Goal

To update mulang and mumukit-inspection to next major version, and benefit from its new features. 

# :memo: Details

This PR updates versions and: 

* Uses smells classifications directly from mulang, thus ensuring always smells are up-to-date
* Allows runners to pass `normalizationOptions` to mulang, thus letting them alter some aspects of the generated asts
* Allows requests to have `normalization_options` in their settings, and forwards them to mulang, thus allowing content-editors to alter the ast in an per-exercise basis. 

# :back: Backward compatibility

This PR should be mostly backward compatible. However, as every mulang update implies, it may break tests because of new smells. 

# :warning: Warnings

* Depends on https://github.com/mumuki/mumukit-inspection/pull/25