### PR TITLE
Add support for original language and rules

### DIFF
--- a/lib/mumukit/templates/mulang_expectations_hook.rb
+++ b/lib/mumukit/templates/mulang_expectations_hook.rb
@@ -24,7 +24,11 @@ module Mumukit
           exclude: (expectations[:exceptions] + default_smell_exceptions)
         },
         domainLanguage: domain_language
-      }.merge({normalizationOptions: normalization_options(request).presence}.compact))
+      }.merge({
+        originalLanguage: original_language,
+        autocorrectionRules: autocorrection_rules.try { |it| positive_and_negative it }.presence,
+        normalizationOptions: normalization_options(request).presence
+      }.compact))
     end
 
     def run_mulang_analysis(analysis)
@@ -32,7 +36,6 @@ module Mumukit
     rescue JSON::ParserError
       raise Mumukit::CompilationError, "Can not handle mulang results for analysis #{analysis}"
     end
-
 
     def domain_language
       {
@@ -44,6 +47,13 @@ module Mumukit
 
     def normalization_options(request)
       request.dig(:settings, :normalization_options) || {}
+    end
+
+    def autocorrection_rules
+      {}
+    end
+
+    def original_language
     end
 
     def default_smell_exceptions
@@ -80,6 +90,12 @@ module Mumukit
       if value
         include Mumukit::Templates::WithCodeSmells
       end
+    end
+
+    private
+
+    def positive_and_negative(rules)
+      rules.flat_map { |k, v| [[k, v], ["Not:#{k}", "Not:#{v}"]] }.to_h
     end
   end
 end

--- a/spec/mulang_expectations_hook_spec.rb
+++ b/spec/mulang_expectations_hook_spec.rb
@@ -193,6 +193,45 @@ describe Mumukit::Templates::MulangExpectationsHook do
                               }
     end
 
+    context 'with original language' do
+      let(:request) { {content: content } }
+      before do
+        class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+          def language
+            'Mulang'
+          end
+
+          def original_language
+            'Ruby'
+          end
+
+          def compile_content(*)
+            {tag: :None}
+          end
+        end
+      end
+
+      it { expect(sample).to eq sample: {
+                                  tag: 'MulangSample',
+                                  ast: {tag: :None},
+                                },
+                                spec: {
+                                  customExpectations: nil,
+                                  domainLanguage: {
+                                    caseStyle: "CamelCase",
+                                    jargon: [],
+                                    minimumIdentifierSize: 3
+                                  },
+                                  originalLanguage: 'Ruby',
+                                  expectations: [],
+                                  smellsSet: {
+                                    tag: "AllSmells",
+                                    exclude: []
+                                  }
+                                }
+                              }
+    end
+
     context 'when transform_content is provided' do
       before do
         class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook

--- a/spec/mulang_expectations_hook_spec.rb
+++ b/spec/mulang_expectations_hook_spec.rb
@@ -232,6 +232,54 @@ describe Mumukit::Templates::MulangExpectationsHook do
                               }
     end
 
+    context 'with original language' do
+      let(:request) { {content: content } }
+      before do
+        class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook
+          def language
+            'Mulang'
+          end
+
+          def autocorrection_rules
+            {
+              "Uses:+" => "UsesPlus",
+              "Uses:=*" => "UsesMultiply",
+            }
+          end
+
+          def compile_content(*)
+            {tag: :None}
+          end
+        end
+      end
+
+      it { expect(sample).to eq sample: {
+                                  tag: 'MulangSample',
+                                  ast: {tag: :None},
+                                },
+                                spec: {
+                                  customExpectations: nil,
+                                  domainLanguage: {
+                                    caseStyle: "CamelCase",
+                                    jargon: [],
+                                    minimumIdentifierSize: 3
+                                  },
+                                  autocorrectionRules: {
+                                    "Not:Uses:+"=>"Not:UsesPlus",
+                                    "Not:Uses:=*"=>"Not:UsesMultiply",
+                                    "Uses:+"=>"UsesPlus",
+                                    "Uses:=*"=>"UsesMultiply"
+                                  },
+                                  expectations: [],
+                                  smellsSet: {
+                                    tag: "AllSmells",
+                                    exclude: []
+                                  }
+                                }
+                              }
+    end
+
+
     context 'when transform_content is provided' do
       before do
         class DemoExpectationsHook < Mumukit::Templates::MulangExpectationsHook


### PR DESCRIPTION
# :dart: Goal

Allow runners to pass their own autocorrection rules and to specify the original language - which is important when the code is provided as a plain AST. 