### PR TITLE
Feature error transformation improvements

### DIFF
--- a/lib/mumukit/error_pattern.rb
+++ b/lib/mumukit/error_pattern.rb
@@ -1,11 +1,12 @@
 module Mumukit
   class ErrorPattern
-    def initialize(regexp)
+    def initialize(regexp, status: :failed)
       @regexp = regexp
+      @status = status
     end
 
-    def matches?(result)
-      @regexp.matches? result
+    def matches?(result, status)
+      @status.like?(status) && @regexp.matches?(result)
     end
 
     def sanitize(result)

--- a/lib/mumukit/error_pattern.rb
+++ b/lib/mumukit/error_pattern.rb
@@ -1,8 +1,9 @@
 module Mumukit
   class ErrorPattern
-    def initialize(regexp, status: :failed)
+    def initialize(regexp, status: :failed, replace: '')
       @regexp = regexp
       @status = status
+      @replacement = replace
     end
 
     def matches?(result, status)
@@ -10,7 +11,7 @@ module Mumukit
     end
 
     def sanitize(result)
-      result.gsub(@regexp, '').strip
+      result.gsub(@regexp, @replacement).strip
     end
 
     def transform(result, status)

--- a/lib/mumukit/templates/with_error_patterns.rb
+++ b/lib/mumukit/templates/with_error_patterns.rb
@@ -1,8 +1,8 @@
 module Mumukit::Templates
   module WithErrorPatterns
     def post_process_file(_file, result, status)
-      error_patterns.each { |it| return it.transform(result, status) if it.matches? result } if status.failed?
-      super
+      pattern = error_patterns.find { |it| it.matches? result, status }
+      pattern ? pattern.transform(result, status) : super
     end
 
     def error_patterns

--- a/lib/mumukit/templates/with_structured_results.rb
+++ b/lib/mumukit/templates/with_structured_results.rb
@@ -7,7 +7,7 @@ module Mumukit::Templates::WithStructuredResults
       post_process_unstructured_result(file, result, status)
     end
   rescue JSON::ParserError
-    [result, :errored]
+    post_process_unstructured_result(file, result, :errored)
   end
 
   def post_process_unstructured_result(_file, result, status)

--- a/mumukit.gemspec
+++ b/mumukit.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sinatra-cross_origin', '~> 0.4'
   spec.add_dependency 'mime-types', '~> 3.2'
 
-  spec.add_dependency 'mulang', '~> 6.0'
+  spec.add_dependency 'mulang', '~> 6.0', '>= 6.0.4'
   spec.add_dependency 'mumukit-inspection', '~> 6.0'
 
   spec.add_dependency 'mumukit-core', '~> 1.3'

--- a/spec/mulang_expectations_hook_spec.rb
+++ b/spec/mulang_expectations_hook_spec.rb
@@ -175,7 +175,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
                                   content: content,
                                   language: 'JavaScript' },
                                 spec: {
-                                  customExpectations: nil,
+                                  includeOutputAst: false,
                                   domainLanguage: {
                                     caseStyle: "CamelCase",
                                     jargon: [],
@@ -216,7 +216,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
                                   ast: {tag: :None},
                                 },
                                 spec: {
-                                  customExpectations: nil,
+                                  includeOutputAst: false,
                                   domainLanguage: {
                                     caseStyle: "CamelCase",
                                     jargon: [],
@@ -258,7 +258,7 @@ describe Mumukit::Templates::MulangExpectationsHook do
                                   ast: {tag: :None},
                                 },
                                 spec: {
-                                  customExpectations: nil,
+                                  includeOutputAst: false,
                                   domainLanguage: {
                                     caseStyle: "CamelCase",
                                     jargon: [],

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -17,7 +17,8 @@ describe Mumukit::Server::TestServer do
       def error_patterns
         [
           Mumukit::ErrorPattern::Errored.new(/^syntax error: /),
-          Mumukit::ErrorPattern::Errored.new(/^Warning: /, status: :passed)
+          Mumukit::ErrorPattern::Errored.new(/^Warning: /, status: :passed),
+          Mumukit::ErrorPattern::Errored.new(/^Lint message: /, status: :passed, replace: 'Error: ')
         ]
       end
     end
@@ -62,6 +63,12 @@ describe Mumukit::Server::TestServer do
       before { allow_any_instance_of(DemoQueryHook).to receive(:run_file!) { ['Warning: singleton variables found', :passed] } }
 
       it { expect(server.query!(req query: '[].map {')).to eq(exit: :errored, out: 'singleton variables found') }
+    end
+
+    context 'passed status with replacement' do
+      before { allow_any_instance_of(DemoQueryHook).to receive(:run_file!) { ['Lint message: unused var', :passed] } }
+
+      it { expect(server.query!(req query: '[].map {')).to eq(exit: :errored, out: 'Error: unused var') }
     end
   end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -16,7 +16,8 @@ describe Mumukit::Server::TestServer do
 
       def error_patterns
         [
-          Mumukit::ErrorPattern::Errored.new(/^syntax error: /)
+          Mumukit::ErrorPattern::Errored.new(/^syntax error: /),
+          Mumukit::ErrorPattern::Errored.new(/^Warning: /, status: :passed)
         ]
       end
     end
@@ -51,8 +52,16 @@ describe Mumukit::Server::TestServer do
   end
 
   context 'with error defined in patterns' do
-    before { allow_any_instance_of(DemoQueryHook).to receive(:run_file!) { ['syntax error: unexpected end-of-input', :failed] } }
-    
-    it { expect(server.query!(req query: '[].map {')).to eq(exit: :errored, out: 'unexpected end-of-input') }
+    context 'failed status' do
+      before { allow_any_instance_of(DemoQueryHook).to receive(:run_file!) { ['syntax error: unexpected end-of-input', :failed] } }
+
+      it { expect(server.query!(req query: '[].map {')).to eq(exit: :errored, out: 'unexpected end-of-input') }
+    end
+
+    context 'passed status' do
+      before { allow_any_instance_of(DemoQueryHook).to receive(:run_file!) { ['Warning: singleton variables found', :passed] } }
+
+      it { expect(server.query!(req query: '[].map {')).to eq(exit: :errored, out: 'singleton variables found') }
+    end
   end
 end


### PR DESCRIPTION
# :dart: Goal

To allow implementors to transform error messages with more ease

# :memo: Details

* Now `post_process_unstructured_result` will be called even when structured transformer fails to parse the result JSON
* The error patterns have been generalized in order to customize replacement and to make them work even under non-failed conditions. 
