### PR TITLE
Fix dangling volumes

### DIFF
--- a/lib/mumukit/isolated_environment.rb
+++ b/lib/mumukit/isolated_environment.rb
@@ -11,22 +11,21 @@ module Mumukit
       dirnames = filenames.map { |it| Pathname.new(it).dirname }.uniq
 
       binds = dirnames.map { |it| "#{it}:#{it}" }
-      volumes = Hash[dirnames.map { |it| [[it, {}]] }]
 
       command = yield(*filenames)
       command = command.split if command.is_a? String
 
-      configure_container! command, binds, volumes
+      configure_container! command, binds
     end
 
-    def configure_container!(command, binds, volumes)
+    def configure_container!(command, binds)
       self.container = Docker::Container.create(
-        'Image' => Mumukit.config.docker_image,
-        'Cmd' => command,
-        'NetworkDisabled' => true,
-        'HostConfig' => {
-            'Binds' => binds},
-        'Volumes' => volumes)
+        image: Mumukit.config.docker_image,
+        cmd: command,
+        hostConfig: {
+          binds: binds
+        },
+        networkDisabled: true)
     end
 
     def run!

--- a/mumukit.gemspec
+++ b/mumukit.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport'
   spec.add_dependency 'i18n', '~> 0.7'
   spec.add_dependency 'puma'
-  spec.add_dependency 'docker-api', '~> 1.22.2'
+  spec.add_dependency 'docker-api', '~> 1.25'
   spec.add_dependency 'excon', '~> 0.71'
 
 

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -1,0 +1,31 @@
+require_relative './spec_helper'
+require 'tempfile'
+
+describe Mumukit::IsolatedEnvironment do
+  class DemoRunner
+    include Mumukit::Templates::WithIsolatedEnvironment,
+            Mumukit::WithTempfile
+
+    def tempfile_extension
+      '.sh'
+    end
+
+    def command_line(file)
+      "sh #{file}"
+    end
+  end
+
+  context '#run_files' do
+    let(:runner) { DemoRunner.new }
+    let(:file) { runner.write_tempfile!('echo foo') }
+    let!(:volumes_at_start) { Docker::Volume.all.count }
+    let!(:out) { runner.run_files!(file) }
+    let(:volumes_at_end)    { Docker::Volume.all.count }
+
+    it { expect(out).to eq ["foo\n", :passed] }
+
+    it 'leaves no dangling volumes' do
+      expect(volumes_at_end).to eq volumes_at_start
+    end
+  end
+end


### PR DESCRIPTION
I've been reviewing this flow and AFAICT we're not actually using docker-api's volumes at all.

My first approach before I realized that was to run a `Docker::Volume.prune` on `env.destroy!` but that was too violent; it would destroy volumes not associated to the container that was created too. I also managed to destroy volumes associated only with the created container but ended up going for this.

It can be confusing since `docker run` uses the same flag to mount a file/directory and mounting a docker volume but for docker-api these are split between `'Volumes'` and `'Binds'`